### PR TITLE
Foreign interests post grammar corrections

### DIFF
--- a/_posts/2022-08-28-foreign-interests-end.md
+++ b/_posts/2022-08-28-foreign-interests-end.md
@@ -6,27 +6,27 @@ With the Foreign Interests theatre, set in Sefrou-Ramal, coming to a close Synix
 <img src="/assets/img/posts/2022-08-28-foreign-interests-end/arsey.webp"
      alt="Arsey, looking at the horizon"
      style="width:968px;height:auto" />
-*Company treasurer Arsey Johnson during a contract*
+*Synixe treasurer Arsey Johnson during a contract*
 
 ## Theatre Background
 
 <img src="/assets/img/posts/2022-08-28-foreign-interests-end/brett.webp"
      alt="Brett posing"
      style="width:968px;height:auto" />
-*Company president Brett Harrison during a contract*
+*Synixe president Brett Harrison during a contract*
 
 During the Foreign Interests theatre, Synixe Contractors saw itself under the employment of Daltgreen Mining & Exploration Ltd., a multinational mining company.
 
 After Sefrou-Ramal elected a new president, resulting in a more democratic government being established, the UNA was deployed to assist in the transition. After the change in leadership, multinationals started to settle in the country and took the lead in the industrialization process of the country, angering a group of insurgents who decided to take matters into their own hands.
 
-When insurgents opened fire on the workers of a Daltgreen mine and proceeded to bomb it the multinational decided to hire Synixe Contractors to provide security and logistics services to secure all industrial endeavors in the area.
+When insurgents opened fire on the workers of a Daltgreen mine and proceeded to bomb it the company decided to hire Synixe Contractors to provide security and logistics services to secure all industrial endeavors in the area.
 
 ## Synixe's Operations
 
 <img src="/assets/img/posts/2022-08-28-foreign-interests-end/convoy.webp"
      alt="Convoy"
      style="width:968px;height:auto" />
-*Contractors transpotring mining equipment*
+*Contractors transporting mining equipment*
 
 During the theatre Synixe provided a wide range of services for Daltgreen, these included:
 


### PR DESCRIPTION
-Fixed "transpotring"
-Changed "company" to "Synixe" in order to avoid confusion
-Changed "multinational" to "company", Daltgreen seemed redundant